### PR TITLE
docs: update steering memo after deploy verification

### DIFF
--- a/.steering/2026-05-07-progress.md
+++ b/.steering/2026-05-07-progress.md
@@ -1,0 +1,85 @@
+# 2026-05-07 Progress
+
+## 概要
+
+残件の先頭から再開し、PR #2 状態確認と Sanity 実接続の検証を実施しました。  
+`.env` を使った実環境接続で Sanity schema validate と Astro build を通し、Publish 済み Post が静的ページとして生成されることまで確認済みです。
+
+---
+
+## 現在のブランチ状態
+
+- ブランチ: `main`
+- リモート: `origin/main` を追跡
+- 作業ツリー: `mise.toml` が untracked（既存ローカル差分）
+
+---
+
+## 今回完了した項目
+
+### 1. 残件 A の確認（PR #2）
+
+- PR #2 はすでに merged 済みであることを確認
+- PR URL: <https://github.com/dodo5522/blog-tech/pull/2>
+- merged at: 2026-04-25
+- GitHub API で commit status の詳細取得を試行したが、対象 commit の `statuses` は空
+
+補完として、ローカルで validate 相当を再実行:
+
+- `pnpm format:check` 成功
+- `pnpm lint` 成功
+- `pnpm build` 成功
+
+### 2. 残件 B の進捗（Sanity 実運用接続）
+
+- `.env` 設定後に Sanity 接続検証を実施
+- `pnpm exec sanity schema validate` 成功（Errors 0 / Warnings 0）
+- `pnpm build` 成功
+- Publish 後の再 build で記事ページ生成を確認
+  - `/blog/test-content/index.html`
+  - `/tags/test/index.html`
+
+この時点で、Sanity の公開データを build 時取得して静的生成できることを確認済み。
+
+---
+
+## 未完了 / 残件（更新後）
+
+### C. デプロイの本番接続
+
+- AWS 実リソースを Terraform で適用する
+- GitHub Actions の `vars` / `secrets` を設定する
+- `AWS_DEPLOY_ROLE_ARN`、`S3_BUCKET_NAME`、`CLOUDFRONT_DISTRIBUTION_ID` を実値に置き換える
+- 本番 deploy workflow の実行確認を行う
+
+### D. Sanity webhook の接続
+
+- publish / unpublish を契機に GitHub Actions を起動する仕組みを実配線する
+- `repository_dispatch` の発火方法を確定する
+- webhook 失敗時の再送・監視方法を運用文書に具体化する
+
+### E. 404 / CDN 挙動の実機確認
+
+- CloudFront 配下で静的配信の 404 応答が意図通りか確認する
+- カスタムエラーレスポンスと `404.html` の見え方を確認する
+
+### F. コンテンツ品質と UI の polish
+
+- 実記事データでコードブロック、画像、本文余白を確認する
+- OGP 画像の実データ運用を確認する
+- fallback コンテンツに依存しない状態へ移行する
+
+### G. ドキュメント具体化
+
+- `docs/DEPLOYMENT.md` に実運用のロールバック手順を追記する
+- `docs/OPERATIONS.md` に webhook 実運用時の確認手順を追記する
+- `README.md` に初回セットアップ手順を具体化する
+
+---
+
+## 次に着手すべき順序
+
+1. 残件 C の前提となる AWS 実値（role/bucket/distribution）を確定する
+2. GitHub Actions の `vars` / `secrets` を設定する
+3. deploy workflow を手動実行して S3 sync / CloudFront invalidation まで確認する
+4. 残件 D（Sanity webhook）を実配線し、publish トリガーで自動反映を確認する

--- a/.steering/2026-05-08-progress.md
+++ b/.steering/2026-05-08-progress.md
@@ -1,0 +1,75 @@
+# 2026-05-08 Progress
+
+## 概要
+
+本番デプロイ実接続を完了しました。  
+既存の AWS リソース（S3 / CloudFront / SSL cert / domain）を利用し、GitHub Actions の `Deploy` workflow を OIDC ロールで実行してデプロイ成功、公開サイト表示も正常であることを確認済みです。
+
+---
+
+## 現在のブランチ状態
+
+- ブランチ: `feat/sanity-content`
+- 追跡: `origin/feat/sanity-content`
+- 作業ツリー: `.sanity/` と `mise.toml` が untracked（既存ローカル差分）
+
+---
+
+## 今回完了した項目
+
+### 1. GitHub Actions デプロイ実接続
+
+- Repository Variables / Secrets を設定
+- `AWS_DEPLOY_ROLE_ARN` を設定
+- IAM Role: `arn:aws:iam::925849551550:role/github-actions-deploy-blogs`
+- `workflow_dispatch` で `Deploy` を手動実行し成功
+
+確認できたこと:
+
+- `Configure AWS credentials` 成功
+- `aws s3 sync` 成功
+- `aws cloudfront create-invalidation` 成功
+
+### 2. デプロイ後の公開確認
+
+- CloudFront 経由の公開サイトが正常表示されることを確認
+
+---
+
+## 補足メモ（運用上の注意）
+
+- 現在の trust policy が `main` 限定の場合、`feat/*` からの deploy は失敗する
+- 本番運用では `main` 限定を維持する方針が安全
+
+---
+
+## 未完了 / 残件（更新後）
+
+### D. Sanity webhook の実配線
+
+- publish / unpublish を契機に `repository_dispatch` を発火
+- 失敗時の再送・監視手順を具体化
+
+### E. 404 / CDN 挙動の実機確認
+
+- CloudFront 配下で `404.html` とカスタムエラーレスポンスの挙動確認
+
+### F. コンテンツ品質と UI の polish
+
+- 実記事データでコードブロック/画像/本文余白を確認
+- OGP 画像運用確認
+- fallback 依存の最終整理
+
+### G. ドキュメント具体化
+
+- `docs/DEPLOYMENT.md` に実運用ロールバック手順を追記
+- `docs/OPERATIONS.md` に webhook 運用確認手順を追記
+- `README.md` に初回セットアップ手順を具体化
+
+---
+
+## 次に着手すべき順序
+
+1. 残件 D（Sanity webhook 実配線）
+2. 残件 E（CloudFront 404 実機確認）
+3. 残件 G（運用ドキュメント更新）

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "@sanity/client": "7.10.0",
     "@sanity/vision": "4.6.1",
     "astro": "5.13.5",
-    "sanity": "4.6.1"
+    "sanity": "4.6.1",
+    "styled-components": "^6.4.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       sanity:
         specifier: 4.6.1
         version: 4.6.1(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.14))(@types/node@24.1.0)(@types/react@19.2.14)(immer@10.2.0)(jiti@2.6.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.2)(yaml@2.8.3)
+      styled-components:
+        specifier: ^6.4.0
+        version: 6.4.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.8


### PR DESCRIPTION
## Summary
- add steering memo for 2026-05-08
- record production deploy connection success and remaining tasks
- keep local untracked files (.sanity/, mise.toml) out of commit

## Verification
- deployment workflow succeeded previously via workflow_dispatch
- production site confirmed accessible