### PR TITLE
docs: finalize sanity webhook wiring steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist
 *.tfstate.*
 .env
 .env.local
+.sanity
+mise.toml

--- a/.steering/2026-05-08-progress.md
+++ b/.steering/2026-05-08-progress.md
@@ -7,15 +7,18 @@
 
 ---
 
-## 現在のブランチ状態
+## 現在のブランチ状態（最終更新）
 
-- ブランチ: `feat/sanity-content`
-- 追跡: `origin/feat/sanity-content`
-- 作業ツリー: `.sanity/` と `mise.toml` が untracked（既存ローカル差分）
+- ローカル作業ブランチ: `feat/sanity-webhook-wiring`
+- 追跡: `origin/feat/sanity-webhook-wiring`
+- PR:
+  - `#5` `docs: finalize webhook and deploy operations`（マージ済み）
+  - `#6` `docs: finalize sanity webhook wiring steps`（作成済み、`.gitignore` 更新を追加 push 済み）
+- 作業ツリー: クリーン
 
 ---
 
-## 今回完了した項目
+## 今回完了した項目（更新）
 
 ### 1. GitHub Actions デプロイ実接続
 
@@ -34,6 +37,19 @@
 
 - CloudFront 経由の公開サイトが正常表示されることを確認
 
+### 3. ドキュメントの実運用具体化（PR #5）
+
+- `deploy.yml`/`README.md`/`docs/DEPLOYMENT.md`/`docs/OPERATIONS.md`/`docs/RELEASE_CHECKLIST.md` を更新
+- 既存 AWS リソース利用前提のデプロイ手順と、404確認・運用手順を具体化
+- `production environment guard` は運用方針に合わせて削除済み
+
+### 4. Sanity webhook 実配線ガイド強化（PR #6）
+
+- Sanity Webhook 設定値（URL/Method/Trigger/Dataset）を具体化
+- `repository_dispatch` 用トークンの必要権限を明記
+- 403/404 時の切り分けと再送手順を運用文書へ反映
+- `.gitignore` に `.sanity` / `mise.toml` を追加
+
 ---
 
 ## 補足メモ（運用上の注意）
@@ -45,10 +61,11 @@
 
 ## 未完了 / 残件（更新後）
 
-### D. Sanity webhook の実配線
+### D. Sanity webhook の本番有効化確認
 
-- publish / unpublish を契機に `repository_dispatch` を発火
-- 失敗時の再送・監視手順を具体化
+- Sanity 管理画面で webhook を実際に作成する
+- publish/unpublish で `repository_dispatch` による Deploy 起動を確認する
+- webhook token 権限不足（403）にならないことを実運用トークンで確認する
 
 ### E. 404 / CDN 挙動の実機確認
 
@@ -60,16 +77,23 @@
 - OGP 画像運用確認
 - fallback 依存の最終整理
 
-### G. ドキュメント具体化
+### G. ドキュメント最終反映
 
-- `docs/DEPLOYMENT.md` に実運用ロールバック手順を追記
-- `docs/OPERATIONS.md` に webhook 運用確認手順を追記
-- `README.md` に初回セットアップ手順を具体化
+- PR #6 マージ後に docs 状態を再確認し、必要なら微修正
+
+### H. Sanity Studio の静的配信基盤構築（別 S3 + CloudFront）
+
+- Sanity Studio 用の S3 バケットと CloudFront Distribution をブログ本体と分離して用意する
+- `sanity build` 出力を Studio 用 S3 にデプロイする CI/CD を整備する
+- デプロイ時に Studio 用 CloudFront invalidation を実行する
+- Sanity 側の CORS / 許可オリジンに Studio の CloudFront URL を登録する
+- `sanity.config.ts` の `projectId` / `dataset` など本番向け設定を最終確認する
 
 ---
 
 ## 次に着手すべき順序
 
-1. 残件 D（Sanity webhook 実配線）
-2. 残件 E（CloudFront 404 実機確認）
-3. 残件 G（運用ドキュメント更新）
+1. PR #6 をマージ
+2. Sanity webhook を本番作成し、publish 起点の自動デプロイ成功を確認
+3. CloudFront 404 実機確認
+4. Sanity Studio の別配信（S3 + CloudFront）を構築し、配信確認

--- a/.steering/2026-05-18-progress.md
+++ b/.steering/2026-05-18-progress.md
@@ -1,0 +1,58 @@
+# 2026-05-18 Progress
+
+## 概要
+
+Sanity webhook の本番有効化確認と CloudFront 404 実機確認が完了した。
+
+---
+
+## 完了した項目
+
+### D. Sanity webhook の本番有効化確認
+
+- Sanity 管理画面で webhook を作成済み
+- Sanity Studio を `sanity dev` で起動し、記事更新後の Publish で webhook が配送されることを確認済み
+- GitHub fine-grained PAT に `Contents: Read and write` を付与し、Sanity webhook の `Projection` に `event_type` を設定済み
+- Publish 起点で `repository_dispatch` による GitHub Actions `Deploy` workflow 起動を確認済み
+
+### E. 404 / CDN 挙動の実機確認
+
+- CloudFront 配下で `404.html` とカスタムエラーレスポンスの挙動確認済み
+
+### ドキュメント補足
+
+- GitHub `repository_dispatch` 用 PAT は Sanity webhook の `Secret` 欄ではなく、HTTP Header の `Authorization: Bearer <token>` に設定することを `docs/DEPLOYMENT.md` / `docs/OPERATIONS.md` に明記した
+- Sanity webhook の `Secret` 欄は署名検証用であり、GitHub API 認証には使わない
+- GitHub `repository_dispatch` 用 fine-grained PAT の必要権限を `Actions: Read and write` から `Contents: Read and write` に修正した
+- `deploy.yml` の `on.repository_dispatch.types`、Sanity webhook の `event_type`、GitHub PAT の `Contents: Read and write` 権限の対応関係を `docs/DEPLOYMENT.md` に追記した
+- Sanity webhook では送信 body を `Payload` / `Body` ではなく `Projection` で定義すること、未設定時は Sanity document 全体が送信され GitHub API で 422 になることを `docs/DEPLOYMENT.md` / `docs/OPERATIONS.md` に追記した
+
+---
+
+## 未完了 / 残件
+
+### F. コンテンツ品質と UI の polish
+
+- 実記事データでコードブロック / 画像 / 本文余白を確認
+- OGP 画像運用確認
+- fallback 依存の最終整理
+
+### G. ドキュメント最終反映
+
+- PR #6 マージ後に docs 状態を再確認し、必要なら微修正
+
+### H. Sanity Studio の静的配信基盤構築（別 S3 + CloudFront）
+
+- Sanity Studio 用の S3 バケットと CloudFront Distribution をブログ本体と分離して用意する
+- `sanity build` 出力を Studio 用 S3 にデプロイする CI/CD を整備する
+- デプロイ時に Studio 用 CloudFront invalidation を実行する
+- Sanity 側の CORS / 許可オリジンに Studio の CloudFront URL を登録する
+- `sanity.config.ts` の `projectId` / `dataset` など本番向け設定を最終確認する
+
+---
+
+## 次に着手すべき順序
+
+1. PR #6 のマージ状態を確認し、必要なら main へ反映する
+2. 実記事データで UI / OGP / fallback 依存を確認する
+3. Sanity Studio の別配信（S3 + CloudFront）を構築し、配信確認する

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -90,12 +90,20 @@ Repository Secrets:
 
 Sanity 側の publish / unpublish を契機に GitHub Deploy workflow を起動する場合、Sanity webhook の HTTP request を GitHub API に向ける。
 
-- URL: `https://api.github.com/repos/<owner>/<repo>/dispatches`
-- Method: `POST`
-- Header:
-  - `Accept: application/vnd.github+json`
-  - `Authorization: Bearer <dispatch token>`
-- Body:
+この連携は以下の対応関係で動く。
+
+1. Sanity webhook が GitHub REST API の `POST /repos/<owner>/<repo>/dispatches` を呼び出す
+2. GitHub API が `repository_dispatch` イベントを対象 repository に作成する
+3. `.github/workflows/deploy.yml` の `on.repository_dispatch.types` が `event_type` と一致すると `Deploy` workflow が起動する
+
+このため、Sanity webhook の `Projection` で送信 body に設定する `event_type` は、`deploy.yml` の `repository_dispatch.types` と一致させる必要がある。
+
+```yaml
+on:
+  repository_dispatch:
+    types:
+      - sanity-content-changed
+```
 
 ```json
 {
@@ -103,7 +111,57 @@ Sanity 側の publish / unpublish を契機に GitHub Deploy workflow を起動�
 }
 ```
 
-dispatch token は `repo` 権限を持つトークンを使い、Sanity 側 Secret として保持する。
+GitHub PAT の権限は `Deploy` workflow を直接操作する権限ではなく、`repository_dispatch` イベントを repository に作成するための権限として判定される。  
+そのため Fine-grained PAT では `Actions: Read and write` ではなく、GitHub API の `Create a repository dispatch event` 要件に従って `Contents: Read and write` を付与する。
+
+Sanity 管理画面（Project > API > Webhooks）で以下を設定する。
+
+- Name: `github-deploy-on-publish`
+- URL: `https://api.github.com/repos/<owner>/<repo>/dispatches`
+- Dataset: `production`（運用 dataset に合わせる）
+- Trigger: publish / unpublish
+- HTTP Method: `POST`
+- API version: 最新安定版（UI 既定値で可）
+
+- URL: `https://api.github.com/repos/<owner>/<repo>/dispatches`
+- Method: `POST`
+- Header:
+  - `Accept: application/vnd.github+json`
+  - `Authorization: Bearer <dispatch token>`
+- Projection:
+
+```groq
+{
+  "event_type": "sanity-content-changed"
+}
+```
+
+Sanity webhook では送信 body を `Payload` や `Body` ではなく `Projection` で定義する。  
+`Projection` を空にすると、変更された Sanity document 全体が body として送信され、GitHub API 側で `event_type` 不足の 422 になる。
+
+dispatch token は次のいずれかを使い、Sanity webhook の HTTP Header に設定する。
+
+重要:
+
+- GitHub PAT は Sanity webhook の `Secret` 欄ではなく、HTTP Header の `Authorization` に設定する
+- Sanity webhook の `Secret` 欄は、受信側が `X-Sanity-Signature` を検証するための署名用 secret であり、GitHub API 認証には使わない
+- この構成では GitHub API が `Authorization: Bearer <dispatch token>` を検証するため、`Secret` 欄は未設定でよい
+
+- Fine-grained PAT: 対象 repo に対して `Contents: Read and write`（最低限）
+- Classic PAT: `repo`（必要最小限で運用）
+
+確認方法（GitHub 側受け口テスト）:
+
+```bash
+gh api repos/<owner>/<repo>/dispatches -X POST -f event_type='sanity-content-changed'
+```
+
+期待結果:
+
+- 成功時は HTTP 204（出力なし）
+- 403 の場合は dispatch token 権限不足。Fine-grained PAT では `Contents: Read and write` と対象 repository へのアクセスを確認する
+- 422 の場合は body 不正。Sanity webhook の `Projection` が `{ "event_type": "sanity-content-changed" }` になっていることを確認する
+- 404 の場合は owner/repo の指定ミスまたはトークン対象外
 
 ---
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -34,9 +34,10 @@
 ### Sanity webhook 設定確認
 
 1. Sanity webhook の送信先が `https://api.github.com/repos/<owner>/<repo>/dispatches` になっていることを確認する
-2. payload が `{"event_type":"sanity-content-changed"}` を送ることを確認する
-3. webhook 用トークンが Secret 管理され、失効期限やローテーション方針があることを確認する
-4. GitHub Actions 側で `Deploy` workflow が `repository_dispatch` を受けることを確認する
+2. `Projection` が `{ "event_type": "sanity-content-changed" }` で、送信 body に `event_type` が含まれることを確認する
+3. webhook 用トークンが HTTP Header の `Authorization: Bearer <token>` に設定され、失効期限やローテーション方針があることを確認する
+4. webhook 用トークンに repository dispatch 実行権限（Fine-grained PAT なら `Contents: Read and write`）があることを確認する
+5. GitHub Actions 側で `Deploy` workflow が `repository_dispatch` を受けることを確認する
 
 ### コード変更を含む release 後の確認
 
@@ -98,10 +99,12 @@
 ### webhook 失敗時の再送手順
 
 1. Sanity 側 webhook ログで失敗イベントを特定する
-2. 失敗原因（401/403/404/5xx）を確認する
-3. Secret や endpoint を修正する
-4. Sanity 管理画面から対象 webhook を再送する
-5. GitHub Actions の `Deploy` 実行を確認する
+2. 失敗原因（401/403/404/422/5xx）を確認する
+3. 403 の場合は GitHub トークン権限（Fine-grained PAT なら `Contents: Read and write`）と対象 repository へのアクセスを見直す
+4. 422 の場合は Sanity webhook の `Projection` が `{ "event_type": "sanity-content-changed" }` になっていることを確認する
+5. Secret や endpoint を修正する
+6. Sanity 管理画面から対象 webhook を再送する
+7. GitHub Actions の `Deploy` 実行を確認する
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify how Sanity webhook Projection maps to GitHub repository_dispatch event_type
- document fine-grained PAT requirements for repository_dispatch, including Contents: Read and write
- add troubleshooting guidance for 401/403/404/422 webhook failures
- record that Sanity publish now triggers the Deploy workflow and keep remaining tasks visible

## Verification
- Confirmed Sanity Studio publish sends the webhook successfully
- Confirmed GitHub Actions Deploy workflow starts from repository_dispatch
- Confirmed CloudFront 404 behavior separately during operations check

## Notes
- Sanity webhook body must be configured via Projection, not Secret or a Payload field
- Remaining larger follow-up: separate S3 + CloudFront distribution for Sanity Studio hosting